### PR TITLE
feat: auth 저장 진행중

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,52 @@
+import { useAuth } from 'hooks/useAuth';
+
+// src/api/auth.ts
+interface SignInResponse {
+  accessKey: string;
+}
+
+export const signIn = async (
+  email: string,
+  password: string
+): Promise<SignInResponse> => {
+  const response = await fetch('http://localhost:8080/user/signIn', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    throw new Error('로그인 실패');
+  }
+
+  return await response.json();
+};
+
+//TODO : 내 정보 가져오기 >> 백엔드 만들어야함
+// export const fetchMyData = async () => {
+//   const { accessKey } = useAuth();
+
+//   if (!accessKey) {
+//     throw new Error('인증되지 않은 사용자입니다.');
+//   }
+
+//   const response = await fetch('http://localhost:8080/MyInfo', {
+//     method: 'GET',
+//     headers: {
+//       Authorization: `Bearer ${accessKey}`,
+//       'Content-Type': 'application/json',
+//     },
+//   });
+
+//   if (!response.ok) {
+//     if (response.status === 403) {
+//       throw new Error('접근 권한이 없습니다.');
+//     } else {
+//       throw new Error('API 호출 실패');
+//     }
+//   }
+
+//   return await response.json();
+// };

--- a/src/api/link.ts
+++ b/src/api/link.ts
@@ -1,0 +1,38 @@
+import { useAuth } from 'hooks/useAuth';
+import { Link } from '../types/Link';
+
+const API_BASE_URL = 'http://localhost:8080';
+
+export const GetMyLinkByLinkId = async (linkId: number): Promise<Link[]> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/link/${linkId}`);
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    const data: Link[] = await response.json();
+    return data;
+  } catch (error) {
+    console.error(`Error fetching links: ${error}`);
+    throw error;
+  }
+};
+
+//TODO : 만들어야 함
+export const GetMyLinkByCategoryId = async (): Promise<Link[]> => {
+  const { accessKey } = useAuth(); // useAuth 훅에서 accessKey를 가져옵니다.
+  if (!accessKey) {
+    throw new Error('Unauthorized: Access key is missing.');
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/links`);
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    const data: Link[] = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error fetching links:', error);
+    throw error;
+  }
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,26 @@
+// src/hooks/useAuth.ts
+import { useState, useEffect } from 'react';
+import { getAccessKey, removeAccessKey } from '../utils/storage';
+
+export const useAuth = () => {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [accessKey, setAccessKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    const key = getAccessKey();
+    if (key) {
+      setAccessKey(key);
+      setIsAuthenticated(true);
+    } else {
+      setIsAuthenticated(false);
+    }
+  }, []);
+
+  const logout = () => {
+    removeAccessKey();
+    setAccessKey(null);
+    setIsAuthenticated(false);
+  };
+
+  return { isAuthenticated, accessKey, logout };
+};

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,73 +1,98 @@
-import { Button, Form, Input, Typography } from "antd";
+import { Button, Form, Input, Typography } from 'antd';
+import { signIn } from 'api/auth';
+import { useState } from 'react';
+import { saveAccessKey } from 'utils/storage';
 
 const LoginPage = () => {
-    const onFinish = (values: string) => {
-        console.log('Success:', values);
-    };
-    const onFinishFailed = (errorInfo: any) => {
-        console.log('Failed:', errorInfo);
-    };
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
 
-    return (
-        <div style={{ height: '100%', padding: '0px 25px 50px 25px '}}>
-            <Typography.Title level={5} style={{ paddingBottom: 8}}>
-                로그인
-            </Typography.Title>
-            <Form
-                name="basic"
-                labelCol={{
-                    span: 8,
-                }}
-                wrapperCol={{
-                    span: 16,
-                }}
-                style={{
-                    maxWidth: 600,
-                }}
-                initialValues={{
-                    remember: true,
-                }}
-                onFinish={onFinish}
-                onFinishFailed={onFinishFailed}
-                autoComplete="off"
-            >
-                <Form.Item
-                    label="Username"
-                    name="username"
-                    rules={[
-                        {
-                        required: true,
-                        message: 'Please input your username!',
-                        },
-                    ]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Password"
-                    name="password"
-                    rules={[
-                        {
-                        required: true,
-                        message: 'Please input your password!',
-                        },
-                    ]}
-                >
-                    <Input.Password />
-                </Form.Item>
+  const handleSignIn = async () => {
+    try {
+      const data = await signIn(email, password);
+      saveAccessKey(data.accessKey);
+      alert('로그인 성공!');
+    } catch (error) {
+      if (error instanceof Error) {
+        alert(error.message);
+      }
+    }
+  };
 
-                <Form.Item
-                    wrapperCol={{
-                        offset: 8,
-                        span: 16,
-                    }}
-                >
-                    <Button type="primary" htmlType="submit">
-                        Submit
-                    </Button>
-                </Form.Item>
-            </Form>
-        </div>
-    )
-}
+  const onFinish = (values: string) => {
+    console.log('Success:', values);
+  };
+  const onFinishFailed = (errorInfo: any) => {
+    console.log('Failed:', errorInfo);
+  };
+
+  return (
+    <div style={{ height: '100%', padding: '0px 25px 50px 25px ' }}>
+      <Typography.Title level={5} style={{ paddingBottom: 8 }}>
+        로그인
+      </Typography.Title>
+      <Form
+        name="basic"
+        labelCol={{
+          span: 8,
+        }}
+        wrapperCol={{
+          span: 16,
+        }}
+        style={{
+          maxWidth: 600,
+        }}
+        initialValues={{
+          remember: true,
+        }}
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
+        autoComplete="off"
+      >
+        <Form.Item
+          label="email"
+          name="email"
+          rules={[
+            {
+              required: true,
+              message: 'Please input your email!',
+            },
+          ]}
+        >
+          <Input
+            type="email"
+            placeholder="이메일"
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Password"
+          name="password"
+          rules={[
+            {
+              required: true,
+              message: 'Please input your password!',
+            },
+          ]}
+        >
+          <Input.Password
+            placeholder="비밀번호"
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </Form.Item>
+
+        <Form.Item
+          wrapperCol={{
+            offset: 8,
+            span: 16,
+          }}
+        >
+          <Button type="primary" htmlType="submit" onClick={handleSignIn}>
+            Submit
+          </Button>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+};
 export default LoginPage;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,12 @@
+// src/utils/storage.ts
+export const saveAccessKey = (accessKey: string): void => {
+  localStorage.setItem('accessKey', accessKey);
+};
+
+export const getAccessKey = (): string | null => {
+  return localStorage.getItem('accessKey');
+};
+
+export const removeAccessKey = (): void => {
+  localStorage.removeItem('accessKey');
+};


### PR DESCRIPTION
## 작업내용
- 로그인 연동
  - `http://localhost:8080/user/signIn` API 연동하여 accessToken 로컬저장소에 저장하기
  - 로그인 / 로그아웃 / 조회 기본 골격 생성
  - 로그인 성공 확인
    - accessToken 저장 후 사용 가능한지 아직 미확인
 
### 이슈
- 존재하지 않거나 필요없는 API 많음
  - 링크 상세, 내 링크 전체조회 api 필요없음
  - 카테고리에 해당하는 링크, 내 정보 등 api 필요
- 헷갈릴 수 있는 명칭
  - link 상세가 아닌 category 상세 . → 추후 개발하면서 변경하기로 결정
- 로그인 실패 시 에러코드 처리 안되어있음
- 모듈화 안되어있음